### PR TITLE
library API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var mergeWays = require('./lib/merge-ways');
+var splitWays = require('./lib/split-ways');
+
+var graphNormalizer = {
+  mergeWays: mergeWays,
+  splitWays: splitWays
+};
+
+module.exports = graphNormalizer;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.6",
   "description": "Takes nodes and ways and turn them into a normalized graph of intersections and ways.",
   "bin": "./bin/normalize-ways",
+  "main": "./index.js",
   "engines": {
     "node": "4.4.3"
   },

--- a/test/merge-ways.test.js
+++ b/test/merge-ways.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tap').test;
-var mergeWays = require('../lib/merge-ways');
+var normalizer = require('../');
 var fs = require('fs');
 var path = require('path');
 
@@ -12,7 +12,7 @@ test('merge-ways', function (t) {
     var before = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/merge-ways/', fixture, 'before')));
     var after = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/merge-ways/', fixture, 'after')));
 
-    var result = mergeWays(before);
+    var result = normalizer.mergeWays(before);
     t.deepEqual(result, after, fixture + ' output matches expected result');
   });
 

--- a/test/split-ways.test.js
+++ b/test/split-ways.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tap').test;
-var splitWays = require('../lib/split-ways');
+var normalizer = require('../');
 var fs = require('fs');
 var path = require('path');
 
@@ -12,7 +12,7 @@ test('split-ways', function (t) {
     var before = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/split-ways/', fixture, 'before')));
     var after = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/split-ways/', fixture, 'after')));
 
-    var result = splitWays(before);
+    var result = normalizer.splitWays(before);
 
     t.deepEqual(result, after, fixture + ' output matches expected result');
   });


### PR DESCRIPTION
https://github.com/mapbox/graph-normalizer/issues/18

This PR implements a library API for accessing the split and merge functions of graph-normalizer. This allows more flexibility than the CLI, enabling use cases like normalizing graphs without tiling.

cc @benjamintd @lily-chai 