### PR TITLE
Using line by line output stream

### DIFF
--- a/bin/normalize-ways
+++ b/bin/normalize-ways
@@ -66,10 +66,14 @@ waysStream.on('data', function (line) {
     ways = splitWays(ways);
     ways = mergeWays(ways);
 
-    fs.writeFile(path.join(outputPath, quadkey + '.json'), ways.map(function (way) {
-      // append quadkey to way id
+    var outputStream = fs.createWriteStream(path.join(outputPath, quadkey + '.json'));
+    for (var i = 0; i < ways.length - 1; i++) {
+      var way = ways[i];
       way.properties.id = way.properties.id + ';' + quadkey;
-      return JSON.stringify(way);
-    }).join('\n'));
+      outputStream.write(JSON.stringify(way) + '\n');
+    }
+    way = ways[ways.length - 1];
+    way.properties.id = way.properties.id + ';' + quadkey;
+    outputStream.write(JSON.stringify(way));
   });
 });


### PR DESCRIPTION
Solving [big string issue](https://github.com/mapbox/graph-normalizer/issues/24)

Spent some time benchmarking between multiple options including solutions like line by line writing and batch writing.
This solution wont hurt performance from what I've seen.

cc @aaronlidman 