### PR TITLE
Handle junction tag in splitting and merging ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Ways that share a node which is not an intersection (only 2 way owners) are merg
 - All way geometries in the original road network have an equivalent in the normalized graph.
 - No intersection ever lies within a normalized way, only at its ends.
 - Normalized way ids keep track of the history of transformations that led to it.
-- `highway`, `oneway`, `bridge` and `tunnel` tags are conserved from the original graph by default.
-- `highway`, `bridge` and `tunnel` tags can be merged using optional arguments. When merging different tags:
+- `highway`, `oneway`, `bridge`, `tunnel` and `junction` tags are conserved from the original graph by default.
+- `highway`, `bridge`, `tunnel` and `junction` tags can be merged using optional arguments. When merging different tags:
   - `highway` tag is set as `unclassified`
   - `tunnel` tag is set to `yes` i.e. we keep the info that there is a tunnel in the merged way
   - `bridge` tag is set to `yes` i.e. we keep the info that there is a bridge in the merged way
-
+  - `junction` tag is set we keep the info about the junction in the merged way

--- a/lib/merge-ways.js
+++ b/lib/merge-ways.js
@@ -179,7 +179,7 @@ module.exports = function (wayList, options) {
       if (options.mergeTunnels) {
         if (opening.properties.hasOwnProperty('tunnel')) combined.properties.tunnel = opening.properties.tunnel;
         else if (closing.properties.hasOwnProperty('tunnel')) combined.properties.tunnel = closing.properties.tunnel;
-      } else if (opening.properties.hasOwnProperty('tunnel')) combined.properties.bridge = opening.properties.bridge;
+      } else if (opening.properties.hasOwnProperty('tunnel')) combined.properties.tunnel = opening.properties.tunnel;
 
       if (options.mergeJunctions) {
         if (opening.properties.hasOwnProperty('junction')) combined.properties.junction = opening.properties.junction;

--- a/lib/merge-ways.js
+++ b/lib/merge-ways.js
@@ -14,6 +14,7 @@ module.exports = function (wayList, options) {
   options.mergeHighways = (options.mergeHighways === undefined) ? false : options.mergeHighways;
   options.mergeTunnels = (options.mergeTunnels === undefined) ? false : options.mergeTunnels;
   options.mergeBridges = (options.mergeBridges === undefined) ? false : options.mergeBridges;
+  options.mergeJunctions = (options.mergeJunctions === undefined) ? false : options.mergeJunctions;
 
   // build node and way hashes
   var nodes = new Map();
@@ -74,6 +75,13 @@ module.exports = function (wayList, options) {
         (
           owners[0].properties.tunnel !==
           owners[1].properties.tunnel
+        )
+      ) ||
+      (
+        (!options.mergeJunctions) &&
+        (
+          owners[0].properties.junction !==
+          owners[1].properties.junction
         )
       )
     ) nodes.delete(node);
@@ -151,7 +159,7 @@ module.exports = function (wayList, options) {
         }
       );
 
-      // persist oneway, highway, bridge, and tunnel tags if they are present
+      // persist oneway, highway, bridge, tunnel, and junction tags if they are present
       if (opening.properties.hasOwnProperty('oneway')) combined.properties.oneway = opening.properties.oneway;
 
       if (options.mergeHighways) {
@@ -172,6 +180,11 @@ module.exports = function (wayList, options) {
         if (opening.properties.hasOwnProperty('tunnel')) combined.properties.tunnel = opening.properties.tunnel;
         else if (closing.properties.hasOwnProperty('tunnel')) combined.properties.tunnel = closing.properties.tunnel;
       } else if (opening.properties.hasOwnProperty('tunnel')) combined.properties.bridge = opening.properties.bridge;
+
+      if (options.mergeJunctions) {
+        if (opening.properties.hasOwnProperty('junction')) combined.properties.junction = opening.properties.junction;
+        else if (closing.properties.hasOwnProperty('junction')) combined.properties.junction = closing.properties.junction;
+      } else if (opening.properties.hasOwnProperty('junction')) combined.properties.junction = opening.properties.junction;
 
       // insert combined way into hash
       ways[combined.properties.id] = combined;

--- a/lib/split-ways.js
+++ b/lib/split-ways.js
@@ -53,6 +53,7 @@ module.exports = function (ways) {
           if (way.properties.hasOwnProperty('tunnel')) waySlice.properties.tunnel = way.properties.tunnel;
           if (way.properties.hasOwnProperty('name')) waySlice.properties.name = way.properties.name;
           if (way.properties.hasOwnProperty('ref')) waySlice.properties.ref = way.properties.ref;
+          if (way.properties.hasOwnProperty('junction')) waySlice.properties.junction = way.properties.junction;
 
           splitWays.push(waySlice);
 
@@ -79,6 +80,7 @@ module.exports = function (ways) {
       if (way.properties.hasOwnProperty('tunnel')) waySlice.properties.tunnel = way.properties.tunnel;
       if (way.properties.hasOwnProperty('name')) waySlice.properties.name = way.properties.name;
       if (way.properties.hasOwnProperty('ref')) waySlice.properties.ref = way.properties.ref;
+      if (way.properties.hasOwnProperty('junction')) waySlice.properties.junction = way.properties.junction;
 
       splitWays.push(waySlice);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/graph-normalizer",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Takes nodes and ways and turn them into a normalized graph of intersections and ways.",
   "main": "./index.js",
   "engines": {


### PR DESCRIPTION
To fix https://github.com/mapbox/oneways/issues/31 graph normalizer must handle `junction` tag similar to `tunnel` and  `bridge`.

Also the PR contains a fix for c&p typo.

/cc @morganherlocker 