### PR TITLE
Engines: >= 4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Takes nodes and ways and turn them into a normalized graph of intersections and ways.",
   "main": "./index.js",
   "engines": {
-    "node": "4.4.3"
+    "node": ">=4.4.3"
   },
   "scripts": {
     "test": "npm run lint && tap -R spec test/*.test.js",


### PR DESCRIPTION
When using `yarn` as a package mangaer, this dependency fails to install due to the engine version being wildly out of date.

In order for this not to be a breaking change I have simply allowed all node versions `>= 4.4.3`. Alternatively we could lock to > 8 or 10, but this arguably be a major version

cc/ @kuanb @nickcordella