### PR TITLE
Remove "8" from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "8": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/8/-/8-0.0.1.tgz",
-      "integrity": "sha1-J9BJqqwyJnucc3e5Ryvy3xW1Pig="
-    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "benjamintd",
   "license": "ISC",
   "dependencies": {
-    "8": "0.0.1",
     "byline": "^5.0.0",
     "concat-stream": "^1.5.2",
     "graceful-fs": "^4.1.9",


### PR DESCRIPTION
New node version in last commit, with questionable package-lock update: https://github.com/mapbox/graph-normalizer/pull/57

This rectifies that by updating the package-lock again.